### PR TITLE
Scala & Rust: Simplify solutions

### DIFF
--- a/yes.rs
+++ b/yes.rs
@@ -1,19 +1,11 @@
 use std::env;
 
-#[allow(while_true)]
 fn main() {
     let args: Vec<String> = env::args().collect();
+    let args = &args[1..];
 
-    match args.len() {
-        1 => {
-            while true {
-                println!("y");
-            }
-        },
-        _ => {
-            while true {
-                println!("{}", args[1]);
-            }
-        },
+    let output = if args.is_empty() { "y".to_string() } else { args.join(" ") };
+    loop {
+        println!("{}", output)
     }
 }

--- a/yes.scala
+++ b/yes.scala
@@ -1,19 +1,8 @@
 object yes {
   def main (args: Array[String]) {
-    if (args.length == 0) {
-      while (true) {
-        println("y")
-      }
-    }
-    else {
-      while (true) {
-        var i = 0
-        var str :String = ""
-        for (i <- 0 until args.length) {
-          str = str + args(i) + " "
-        }
-        println(str)
-      }
+    val output = if (args.isEmpty) { "y" } else { args.mkString(" ") }
+    while (true) {
+      println(output)
     }
   }
 }


### PR DESCRIPTION
Scala one has problems mentioned in https://github.com/mubaris/yes/issues/20 : String is being built on each iteration. Rust one differs from other implementations by printing only the first passed argument, and a bit complicated too.