### PR TITLE
yesmark: Fixed bug where "yes" process won't die.

### DIFF
--- a/yesmark
+++ b/yesmark
@@ -20,12 +20,12 @@ function sample($executable, $args=null, $target=null) {
 	// Create command and expected output.
 	$command = null;
 	if (is_array($executable)) {
-		$command = escapeshellcmd($executable[0]);
+		$command = 'exec '.escapeshellcmd($executable[0]);
 		for ($i = 1; $i < count($executable); $i++) {
 			$command .= ' '.escapeshellarg($executable[$i]);
 		}
 	} else {
-		$command = escapeshellcmd($executable);
+		$command = 'exec '.escapeshellcmd($executable);
 	}
 
 	$expected = "y\n";


### PR DESCRIPTION
There's a [bug]http://bugs.php.net/bug.php?id=39992) where PHP's proc_open will fork and create a child process.

I used the fix [here](http://php.net/manual/en/function.proc-terminate.php#113502) and it solved the issue of "yes" remaining in the background and hogging resources. Coincidentally, it seems to have made the benchmarking more accurate too.