### PR TITLE
Added prolog implementation

### DIFF
--- a/yes.pro
+++ b/yes.pro
@@ -1,0 +1,10 @@
+#!/usr/bin/env swipl
+
+:- initialization main.
+
+main :- current_prolog_flag(argv, Argv),
+        atomics_to_string(Argv, " ", Output),
+        print(Output).
+
+print("")     :- write('y'), nl, print("").
+print(Output) :- write(Output), nl, print(Output).


### PR DESCRIPTION
Basic implementation in Prolog. 
Lines 5-7 parse command line arguments. 
Lines 9-10 pattern match on the input and print appropriately before looping.

The program can be run either directly:
`$ ./yes.pro`
Or using a specific prolog interpreter:
`$ swipl yes.pro`

This makes use of the [SWI Prolog](http://www.swi-prolog.org/) top-level, which can be installed on Debian using:
`% apt install swi-prolog-nox`

Thanks, I hope this helps!
Closes #40