### PR TITLE
Add yes in CoffeeScript and Common Lisp (again)

### DIFF
--- a/yes.clisp
+++ b/yes.clisp
@@ -1,0 +1,2 @@
+(defun yes (&optional (str "y"))
+  (loop (format t "~a" str) (terpri)))

--- a/yes.coffee
+++ b/yes.coffee
@@ -1,0 +1,1 @@
+YES = (str) -> console.log (if str? then str else 'y') while yes


### PR DESCRIPTION
I contributed the `.coffee` file in addressing #58. The CoffeeScript implementation isn't the most ideal one, as `yes` is already a reserved word in CoffeeScript, so I capitalized the function name. Running with 'no parameters' is really running `YES undefined` or `YES null`.

I also hope that you will consider my (much simpler) Common Lisp implementation. I see that although there is an existing Common Lisp implementation, but I saw that #39 is still open, just FYI.