### PR TITLE
yes in OCaml

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -104,3 +104,18 @@ OR
 ```shell
 $ yes(string argument)
 ```
+
+## OCaml
+
+```shell
+$ ocamlopt -o yes yes.ml
+$./yes
+```
+
+OR
+
+```shell
+$ ./yes argument list
+```
+
+

--- a/build.sh
+++ b/build.sh
@@ -538,5 +538,15 @@ BUILD-START "VB" "yes.vb"
 			;;
 	esac
 BUILD-END
+# -------------------------------------
+# OCaml
+BUILD-START "OCaml" "yes.ml"
+	case "$(BUILD-FIND ocaml)" in
+		ocaml)
+			BUILD-RUN ocamlopt -o "${OUT_FILE}" "${SRC_FILE}"
+			;;
+	esac
+BUILD-END
+
 
 

--- a/yes.ml
+++ b/yes.ml
@@ -1,0 +1,9 @@
+let flood str = 
+        while true do
+        ignore (Printf.printf "%s\n" str);
+        done;;
+
+let () = 
+        match Sys.argv with
+        | [| _; str |] -> flood str
+        | _ -> flood "y"


### PR DESCRIPTION
Adds an OCaml implementation of yes.

On Ubuntu, to install the standard OCaml environment:
```shell
# apt install ocaml
```

`Yes.ml` can then be complied and run by
```shell
$ ocamlopt -o yes yes.ml
./yes <args>
``` 
or run interactively by
```shell
$ ocaml yes.ml <args>
```

Please let me know if other documentation should be added.