### PR TITLE
working on: implement yes in Typescript #66

### DIFF
--- a/yes.typescript.ts
+++ b/yes.typescript.ts
@@ -1,0 +1,21 @@
+
+declare var process;
+
+namespace yes {
+
+    // Get output string.
+    let output: string = "y\n";
+
+    if (process.argv.length !== 2) {
+        output = `${process.argv.slice(2).join(' ')}\n`;
+    }
+    
+    // Write.
+    var flood = () => {
+        while (process.stdout.write(buffer) !== false);
+    }
+    
+    const buffer: string = output.repeat(Math.max(1, Math.floor(4096 / output.length)));
+    process.stdout.on('drain', flood);
+    flood();
+}    


### PR DESCRIPTION
Created file `yes.typescript.ts` 
The reason for using .typescript in the name is, once compiled using tsc yes.ts will be converted to yes.js which will overwrite the js implementation. 

We need to run `tsc.cmd yes.typescript.ts --lib es6` to generate the `yes.typescript.js` which has to be executed using `node.exe yes.typescript.js`

Can create a pr for it if you mind explaining me the process for writing the build script in the `build.sh`.

Closes #66 