### PR TITLE
Add Elixir implementation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -141,3 +141,9 @@ OR
 ```shell
 $ clojure yes.clj arguments
 ```
+
+## Elixir
+```shell
+$ iex Yes.exs
+iex(1)> Yes.run "param"
+```

--- a/yes.exs
+++ b/yes.exs
@@ -1,0 +1,6 @@
+defmodule Yes do
+    def run(y \\ "y") do
+        IO.puts y
+        Yes.run y
+    end
+end


### PR DESCRIPTION
It is not the best solution since it is not executable out of the box.
The solution to use it like this : 
`elixir yes.exs [param]`  
Would require the use of build tools like escript or mix.

This solution would require at least two files.
If you don't mind several files decline this PR and I will fix it.