### PR TITLE
Clearing BUILD_LASTEXIT upon BUILD-START

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,7 @@ BUILD-FIND() {
 
 BUILD-START() {
 	BUILD_LASTERROR=""
+	BUILD_LASTEXIT=""
 	BUILD_EXECUTED=false
 	SRC_FILENAME="$2"
 	OUT_FILENAME="$(sed 's/\./-/' <<< "$(basename "$2")")"


### PR DESCRIPTION
Suggested fix for #81 