### PR TITLE
C# argv condition fixed, and whiteline removed.

### DIFF
--- a/yes.cs
+++ b/yes.cs
@@ -3,10 +3,9 @@ class Yes
 	static void Main(string[] argv)
 	{
 		string st = "y";
-		else
+		if(argv.Length > 0)
 		{
 			st = string.Join(" ", argv);
-			
 		}
 		while (true)
 		{


### PR DESCRIPTION
There was no condition checking the size of argv, instead there was an else with no if statement. There was also an empty line that was removed.