### PR TITLE
Fix rust shebang rust->rustc

### DIFF
--- a/yes.rs
+++ b/yes.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env rust
+#!/usr/bin/env rustc
 
 use std::env;
 


### PR DESCRIPTION
I personally don't see much of a benefit to a rust shebang since if you make the file executable and try to use the shebang, it only compiles the code without running it. Nevertheless, this fix makes the shebang work.