### PR TITLE
Update to speed up yes to be on par with system `yes`

### DIFF
--- a/yes.go
+++ b/yes.go
@@ -8,13 +8,26 @@ import (
 var bufsize = 64 * 1024
 
 func main() {
-	y := byte('y')
-	n := byte('\n')
-	buf := make([]byte, bufsize)
-	for i := 0; i < len(buf)-2; i += 2 {
-		buf[i] = y
-		buf[i+1] = n
+	var y []byte
+	// Get arg
+	if len(os.Args) > 1 {
+		y = []byte(os.Args[1] + "\n")
+	} else {
+		// Set output to y
+		y = []byte("y\n")
 	}
+	yLen := len(y)
+
+	// Create buffer
+	buf := make([]byte, bufsize)
+	// Popoulate buffer
+	for i := 0; i < len(buf)-yLen; i += yLen {
+		for s := 0; s < len(y); s++ {
+			buf[i+s] = y[s]
+		}
+	}
+
+	// Create buffered writer
 	f := bufio.NewWriterSize(os.Stdout, bufsize)
 	defer f.Flush()
 	for {

--- a/yes.go
+++ b/yes.go
@@ -1,17 +1,23 @@
 package main
 
 import (
+	"bufio"
 	"os"
-	"strings"
 )
 
-func main() {
-	output := "y"
-	if len(os.Args) > 1 {
-		output = strings.Join(os.Args[1:], " ")
-	}
+var bufsize = 64 * 1024
 
+func main() {
+	y := byte('y')
+	n := byte('\n')
+	buf := make([]byte, bufsize)
+	for i := 0; i < len(buf)-2; i += 2 {
+		buf[i] = y
+		buf[i+1] = n
+	}
+	f := bufio.NewWriterSize(os.Stdout, bufsize)
+	defer f.Flush()
 	for {
-		println(output)
+		f.Write(buf)
 	}
 }


### PR DESCRIPTION
System `yes` command on my system works very fast
```
$ yes | pv -r > /dev/null 
[9.06GiB/s]
```

Therefore I decided to speed up go version of yes to be on par with system version

```
$ ./yes | pv -r > /dev/null
[9.63GiB/s]
```