### PR TITLE
build support for D

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -275,7 +275,12 @@ BUILD-END
 # -------------------------------------
 # D
 BUILD-START "D" "yes.d"
-	BUILD-FAIL "TODO BUILD SCRIPT"
+	case "$(BUILD-FIND rdmd)" in
+		rdmd)
+			rdmd --build-only -of"${BIN}/yes-d" yes.d
+			BUILT true
+			;;
+	esac
 BUILD-END
 
 # -------------------------------------


### PR DESCRIPTION
only supports DMD (official reference compiler for i386 and amd64 architectures)
uses rdmd.exe instead of dmd.exe to build executable
the executable is named "yes-d" and can be found in /bin after running build.sh