### PR TITLE
Fix java main class in wrapper script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -351,7 +351,7 @@ BUILD-START "Java" "yes.java"
 	case "$(BUILD-FIND javac)" in
 		javac)
 			BUILD-RUN javac -d "${OBJ}" "${SRC_FILE}"
-			INTERPRETED-WRAP java -cp "${OBJ}" "yes" '{$@}' > "${OUT_FILE}"
+			INTERPRETED-WRAP java -cp "${OBJ}" "Yes" '{$@}' > "${OUT_FILE}"
 			chmod +x "${OUT_FILE}"
 			;;
 	esac


### PR DESCRIPTION
With lowercase `yes` the java runtime gives this error:

> Error: Could not find or load main class yes