### PR TITLE
Correct bash version: print as-is parameter-like strings

### DIFF
--- a/yes.sh
+++ b/yes.sh
@@ -4,5 +4,5 @@ OUT=$* && [ -z "$OUT" ] && OUT="y"
 
 while :
 do
-    echo "$OUT"
+    printf "%s\n" "$OUT"
 done


### PR DESCRIPTION
When using echo "$OUT", some strings could be interpreted by echo util in
a special way. Thus the output may not be the same as passed in parameters.
This patch fixes it by using printf instead of echo.